### PR TITLE
Allow "local" to be used as remote name for pushing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,15 @@ There is actually an even shorter way (2):
 Common assumptions:
 
 - The upstream remote is `upstream`, `origin`, or the first remote in
-  the `git remote` output, whichever is found first.
+  the `git remote` output, whichever is found first.  The idea is that
+  if you add a remote named `upstream`, it will use that by default.
 
-- You always push the `origin`, `upstream`, or first remote found,
-  whichever comes first.
+- You push to the `local`, `origin`, `upstream`, or first remote in
+  the `git remote` output, whatever comes first.  The idea is that you
+  add a remote called `local`, it will push to that by default.
+  Combined with the above, no matter if you originally clone the
+  upstream or personal fork, you can at most add one more remote and
+  get started (without having to adjust remote names).
 
 
 ## Installation and usage of `git-pr`

--- a/git-pr
+++ b/git-pr
@@ -10,7 +10,7 @@ if [ "$VERBOSE" ] ; then
 fi
 
 inferred_upstream="$(git remote | grep ^upstream || git remote | grep ^origin || git remote | head -1)"
-inferred_origin="$(git remote | grep ^origin || git remote | grep ^upstream || git remote | head -1)"
+inferred_origin="$(git remote | grep ^local || git remote | grep ^origin || git remote | grep ^upstream || git remote | head -1)"
 infer_remote_type() {
     # Determine if remote is github, gitlab, etc.  Should *always*
     # return one option (set default here)


### PR DESCRIPTION
- Before the script semi-required remote names `origin` and
  `upstream`, now you have the choice of `origin`/`upstream`,
  `local`/`origin`, or possibly some combination.