### PR TITLE
Bugfix: When auto-detecting remotes, limit to only one remote.

### DIFF
--- a/git-pr
+++ b/git-pr
@@ -9,8 +9,9 @@ if [ "$VERBOSE" ] ; then
     set -x
 fi
 
-inferred_upstream="$(git remote | grep ^upstream || git remote | grep ^origin || git remote | head -1)"
-inferred_origin="$(git remote | grep ^local || git remote | grep ^origin || git remote | grep ^upstream || git remote | head -1)"
+inferred_upstream="$(git remote | grep --max-count=1 ^upstream || git remote | grep --max-count=1 ^origin || git remote | head -1)"
+inferred_origin="$(git remote | grep  --max-count=1 ^local || git remote | grep --max-count=1 ^origin || git remote | grep  --max-count=1 ^upstream || git remote | head -1)"
+
 infer_remote_type() {
     # Determine if remote is github, gitlab, etc.  Should *always*
     # return one option (set default here)


### PR DESCRIPTION
- For example, when there are remotes "upstream" and "upstream-new",
  the previosu system would have matched both of them.  Still, there
  is no guarenteed order among these two which *can* and probably will
  cause problems, but this at least makes it fail less weirdly.
- Todo: maybe instead we should detect only "^upstream$" for example,
  or print a warning if multiple remotes match?