### PR TITLE
Properly "git pr push" branches with a '/' in their name

### DIFF
--- a/git-pr
+++ b/git-pr
@@ -127,7 +127,7 @@ EOF
 	    MAKE_PR=1
 	    shift
 	fi
-	remote_branch="${2:-${1:-$(git symbolic-ref HEAD | cut -d/ -f3)}}"
+	remote_branch="${2:-${1:-$(git symbolic-ref HEAD | cut -d/ -f3-)}}"
 	if [ -z "$remote_branch" ] ; then
 	    echo "Not currently on a branch, must spetify branch name."
 	    exit 1


### PR DESCRIPTION
Before, it would only take the branch name before the slash, because
`cut` used `-f3`, instead of `-f3-`.