### PR TITLE
Support branches with slash in the name (second)

### DIFF
--- a/git-pr
+++ b/git-pr
@@ -195,7 +195,7 @@ EOF
 	    branch="$1"
 	    shift
 	else
-	    branch=$(git symbolic-ref HEAD | cut -d/ -f3)
+	    branch=$(git symbolic-ref HEAD | cut -d/ -f3-)
 	    if [ -z "$branch" ] ; then
 		echo "Not currently on a branch, must spetify branch name"
 		exit 1


### PR DESCRIPTION
- I missed one "cut" before.