### PR TITLE
Add automatic branch name prefix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,18 @@ Only a brief description is shown here.
   branches.  Warning: *all*.
 
 
+## Configuration
+
+* **branch name prefix:** You may want to always prefix your branches
+  with your name, e.g. `rkdarst/auto-prefix`.  You can set the a git
+  variable using `git config --global git-pr.branchprefix PREFIX/`, and
+  any branch you try to create will have this prefixed to it.  Note:
+  include a trailing `/` or whatever character with your config
+  option.  This is only applied if your `$inferred_upstream` is the
+  same as your `$inferred_origin` (in other words, if you have a
+  separate personal repository, this won't be added).
+
+
 ## Aliases (obsolete)
 
 These are old aliases which predated and somewhat reproduce the

--- a/git-pr
+++ b/git-pr
@@ -84,12 +84,19 @@ EOF
 	    FORCE=-B
 	    shift
 	fi
+	branch_prefix="$(git config --get git-pr.branchprefix)"
+	brname="$1"
+	# If branch name is given AND branch_prefix is given, use
+	# "branch_prefix/branch_name" as the actual branch name.
+	if [ -n "$brname" -a "$inferred_upstream" = "$inferred_origin" ] ; then
+	    brname="${branch_prefix}${brname}"
+	fi
 	# Fetch current HEAD always
 	if [ "$NEW_ALWAYS_FETCH" ] ; then
 	    git fetch ${inferred_upstream} HEAD
-	    git checkout $(test $1 && echo $FORCE $1) FETCH_HEAD
+	    git checkout $(test $brname && echo $FORCE $brname) FETCH_HEAD
 	else
-	    git checkout $(test $1 && echo $FORCE $1) ${inferred_upstream}/HEAD
+	    git checkout $(test $brname && echo $FORCE $brname) ${inferred_upstream}/HEAD
 	    if [ $? -eq 128 ] ; then
 		echo ""
 		echo "ERROR:"


### PR DESCRIPTION
- In join projects, you often like adding a `username/` prefix to your
  branches.  This automates that.
- Configuration via `git config --global git-pr.branchprefix`.  No
  effect unless this is set.
- Currently only applies to cases where the inferred local remote is
  the same as the upstream remote.