### PR TITLE
Fix up unfetchall and add unfetchmerged command

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,14 @@ Only a brief description is shown here.
 * `git pr fetchall`: Fetch all remote upstream PRs to local
   repository.  Warning: this includes all PRs, open and closed.
 
-* `unfetchall`: Remove all `inferred_upstream/pr/$pr_number`
-  branches.  Warning: *all*.
+* `git pr unfetchall`: Remove all `$inferred_upstream/pr/[0-9]+$`
+  branches (remove remote tracking branch is opposite of fetch).
+  Warning: *all*.
+
+* `git pr unfetchmerged`: Remove all PR branches (see above) branches
+  which are merged (according to `--git branch --merged
+  $inferred_origin/HEAD`).  Since you can't fetch just unmerged PRs,
+  normally you would do `fetchall` followed by `unfetchmerged`.
 
 
 ## Configuration

--- a/git-pr
+++ b/git-pr
@@ -336,7 +336,20 @@ upstream.  It will delete anything matching '/pr/[0-9]+'
 EOF
 	    exit
 	fi
-	git branch --remote -d `git branch --remote | grep -E '/pr/[0-9]+$'`
+	git branch --remote -d $(git branch --remote ${inferred_upstream}/HEAD | grep -E "$inferred_upstream/pr/[0-9]\+$")
+	;;
+
+    unfetchmerged)
+	if test -n "$HELP" ; then
+	    cat <<EOF
+git pr unfetchmerged
+
+Delete everything fetched by prfetchall that has already been merged.
+It will delete anything matching '$upstream/pr/[0-9]+'
+EOF
+	    exit
+	fi
+	git branch --remote --quiet -d $(git branch --remote --merged ${inferred_upstream}/HEAD | grep "$inferred_upstream/pr/[0-9]\+$")
 	;;
 
     *)


### PR DESCRIPTION
- unfetchall: remove all the pr/[0-9]+ branches.
- unfetchmerged: remove all pr/[0-9]+ branches which are reported as
  merged to $inferred_upstream/head.

These changes have been dangling around for a while, finally finishing
it up.