### PR TITLE
git pr merged: don't automatically fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ Only a brief description is shown here.
 
 * `git pr merged`: show local and remote branches which can be
   removed.  A small wrapper around `git branch --merged` that always
-  checks relative to upstream/HEAD.  Automatically does fetches and
-  remote reference prunes.  (I welcome UI suggestions for this and the
-  two following commands, how to properly do things automatically.)
+  checks relative to upstream/HEAD.  (I welcome UI suggestions for
+  this and the two following commands, how to properly do things
+  automatically.)
 
 * `git pr rm $branch_name ...`: Remove named branches, both locally
   and on inferred_origin.

--- a/git-pr
+++ b/git-pr
@@ -238,13 +238,10 @@ EOF
 git pr merged
 
 List merged branches.  Similar to "git branch --merged" but uses the
-upstream HEAD by default.  Automatically does fetches and remote
-prunes.
+upstream HEAD by default.
 EOF
 	    exit
 	fi
-	git fetch $inferred_upstream
-	git fetch $inferred_origin --prune
 	git --no-pager branch -a --merged ${inferred_upstream}/HEAD
 	;;
 


### PR DESCRIPTION
- The original UI was to automatically fetch every time you do `git pr
  merged`.
- This was a bad idea, because you often do this several times in
  succession.  Better to let the person decide when to do it.