### PR TITLE
Improve `git pr prune`: delete merged branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,18 +131,18 @@ Only a brief description is shown here.
   Gitlab, etc. - for now opening a merge request can be done in the
   `git pr push -r` command)  `-d` creates a draft pull request.
 
-* `git pr merged`: show local and remote branches which can be
-  removed.  A small wrapper around `git branch --merged` that always
-  checks relative to upstream/HEAD.  (I welcome UI suggestions for
-  this and the two following commands, how to properly do things
-  automatically.)
-
 * `git pr rm $branch_name ...`: Remove named branches, both locally
   and on inferred_origin.
 
+* `git pr merged`: show local and remote branches which can be
+  removed.  A small wrapper around `git branch --merged` that always
+  checks relative to `$inferred_upstream/HEAD`.  (I welcome UI
+  suggestions for this and the two following commands, how to properly
+  do things automatically.)
+
 * `git pr prune`: Remove remote tracking references already deleted
-  upstream (just a shorthand for `git fetch $inferred_origin
-  --prune`).  Note it also fetches.
+  upstream, and {local,remote} branches which are now merged to
+  `$inferred_upstream/HEAD`.
 
 * `git pr fetch $pr_number`: Fetch the given upstream PR to a new
   local remote branch `inferred_upstream/pr/$pr_number`. (all fetch

--- a/git-pr
+++ b/git-pr
@@ -258,11 +258,50 @@ EOF
 git pr merged
 
 List merged branches.  Similar to "git branch --merged" but uses the
-upstream HEAD by default.
+upstream HEAD by default.  Use "git pr prune" to delete them.
 EOF
 	    exit
 	fi
+	# arg parsing
+	while getopts "d" arg ; do
+	    case $arg in
+		d) MERGED_DELETE="1" ;;
+	    esac
+	done
+	shift $((OPTIND-1))
+	#
 	git --no-pager branch -a --merged ${inferred_upstream}/HEAD
+	;;
+
+    prune)
+	if test -n "$HELP" ; then
+	    cat <<EOF
+git pr prune
+
+Remove merged local branches and remote tracking references that are
+already deleted upstream.  This is just as shorthand for other git
+commands that do this.  Roughly, this should delete what you see in "git pr merged".  (This command is beta)
+
+EOF
+	    exit
+	fi
+	# Delete stale references associated with $name.  Also update
+	# other remote tracking refs, because why not...
+	git fetch ${inferred_upstream} --prune
+	test -n "${inferred_origin}" && git fetch ${inferred_origin} --prune
+
+	echo "local"
+	git --no-pager branch --merged ${inferred_upstream}/HEAD \
+	    | cut -c3- | cut -d' ' -f1 \
+	    | grep -E -v 'master|HEAD|gh-pages' \
+	    | xargs git branch --delete
+	echo "remote"
+	git --no-pager branch --remote --merged ${inferred_upstream}/HEAD \
+	    | cut -c3- \
+	    | grep "^${inferred_origin}/" \
+	    | cut -d' ' -f1 \
+	    | grep -E -v 'master|HEAD|gh-pages' | cut -d/ -f2- \
+	    | xargs git push --delete ${inferred_origin}
 	;;
 
     rm)
@@ -281,21 +320,6 @@ EOF
 	    git branch | grep " $brname\$" && git branch -d $brname
 	    git branch -a | grep " remotes/${inferred_origin}/$brname\$" && git push ${inferred_origin} :$brname
 	done
-	;;
-
-    prune)
-	if test -n "$HELP" ; then
-	    cat <<EOF
-git pr prune
-
-Remove remote tracking references that are already deleted upstream.  This
-is just as shorthand for other git commands that do this.
-EOF
-	    exit
-	fi
-	# Delete stale references associated with $name.  Also update
-	# other remote tracking refs, because why not...
-	git fetch $inferred_origin --prune
 	;;
 
     fetch)


### PR DESCRIPTION
Deletes
- local tracking which are now deleted upstream (`git fetch --prune`)
- local branches which are now merged
- remote branches on $inferred_origin which are merged to
  $inferred_upstream.

The goal is that when you have a lot of stuff lying around, you can
just `git pr prune` and automatically get rid of anything that has no
reason to be there.  This command is beta, and has some risk of doing
wrong things!