### PR TITLE
Add set-head command

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ Only a brief description is shown here.
 
 * `git pr info` prints the autodetected remotes and base branches.
 
+* `git pr set-head` checks the remote and sets the remote default branch.
+
 ## Configuration
 
 * **branch name prefix:** You may want to always prefix your branches

--- a/git-pr
+++ b/git-pr
@@ -41,6 +41,7 @@ Subcommands:
   Usual work:  new, push, di, gh
   Cleaning up:  merged, rm, prune
   Fetching PR branches:  fetch, fetchall, unfetchall
+  Meta: info, set-head
 EOF
 }
 
@@ -437,6 +438,18 @@ EOF
 	echo "Detected upstream is ${inferred_upstream}  (we branch from here)"
 	echo "${inferred_upstream}/HEAD is $(git symbolic-ref refs/remotes/${inferred_upstream}/HEAD)"
 	echo "Default base is ${inferred_head}  (fix with \"git remote set-head ${inferred_upstream} --auto\")"
+	;;
+
+    set-head)
+	if test -n "$HELP" ; then
+	    cat <<EOF
+git pr set-head
+
+Check the remote and set the remote default branch.
+EOF
+	    exit
+	fi
+	git remote set-head ${inferred_upstream} --auto
 	;;
 
     *)


### PR DESCRIPTION
- This automatically queries the remote and sets the default branch.
  This can easily be done manually or the one-line automatic command,
  but this saves thinking when you need it.