### PR TITLE
git-pr push -f: use --force-with-lease instead of --force

### DIFF
--- a/git-pr
+++ b/git-pr
@@ -140,7 +140,7 @@ EOF
 	while getopts "dfnr" arg ; do
 	    case $arg in
 		d) PR_DRAFT="-d" ;;
-		f) FORCE="-f" ;;
+		f) FORCE="--force-with-lease" ;;
 		n) PR_NO_EDIT="-n" ;;
 		r) MAKE_PR=1 ;;
 	    esac


### PR DESCRIPTION
- The --force-with-lease option only pushes if the remote hasn't
  relative to our current view of the remote (as in, if no one has
  pushed since we last did).  This is only really useful if you don't
  fetch in the meantime (unless you check it), since fetching updates
  our view of the other end.