### PR TITLE
git-pr: Allow help commands to work outside a repository

### DIFF
--- a/git-pr
+++ b/git-pr
@@ -10,9 +10,12 @@ if [ "$VERBOSE" ] ; then
     set -x
 fi
 
-inferred_upstream="$(git remote | grep --max-count=1 ^upstream || git remote | grep --max-count=1 ^origin || git remote | head -1)"
-inferred_origin="$(git remote | grep  --max-count=1 ^local || git remote | grep --max-count=1 ^origin || git remote | grep  --max-count=1 ^upstream || git remote | head -1)"
+
+infer_remotes() {
+    inferred_upstream="$(git remote | grep --max-count=1 ^upstream || git remote | grep --max-count=1 ^origin || git remote | head -1)"
+    inferred_origin="$(git remote | grep  --max-count=1 ^local || git remote | grep --max-count=1 ^origin || git remote | grep  --max-count=1 ^upstream || git remote | head -1)"
 #inferred_head="$(git symbolic-ref refs/remotes/${inferred_upstream}/HEAD --short)"
+}
 
 infer_remote_type() {
     # Determine if remote is github, gitlab, etc.  Should *always*
@@ -81,6 +84,7 @@ If there is no ${inferred_upstream}/HEAD, then you can set it using:
 EOF
 	    exit
 	fi
+	infer_remotes
 	FORCE=-b
 	# arg parsing
 	while getopts "f" arg ; do
@@ -137,6 +141,7 @@ to be before the arguments.
 EOF
 	    exit
 	fi
+	infer_remotes
 	# arg parsing
 	while getopts "dfnr" arg ; do
 	    case $arg in
@@ -194,6 +199,7 @@ same logic to find upstream merge base as "prnew"
 EOF
 	    exit
 	fi
+	infer_remotes
 	git diff $(git merge-base ${inferred_upstream}/HEAD HEAD) "$@"
 	;;
 
@@ -218,6 +224,7 @@ The options have to be before the arguments
 EOF
 	    exit
 	fi
+	infer_remotes
 	if ! which $HUB >> /dev/null ; then
 	    echo "Please install the hub command line program:"
 	    echo "  https://github.com/github/hub"
@@ -278,6 +285,7 @@ upstream HEAD by default.  Use "git pr prune" to delete them.
 EOF
 	    exit
 	fi
+	infer_remotes
 	# arg parsing
 	while getopts "d" arg ; do
 	    case $arg in
@@ -301,6 +309,7 @@ commands that do this.  Roughly, this should delete what you see in "git pr merg
 EOF
 	    exit
 	fi
+	infer_remotes
 	# Delete stale references associated with $name.  Also update
 	# other remote tracking refs, because why not...
 	git fetch ${inferred_upstream} --prune
@@ -330,6 +339,7 @@ to "git fetch -a" first.
 EOF
 	    exit
 	fi
+	infer_remotes
 	for brname in "$@"; do
 	    brname=${brname#remotes/${inferred_origin}/}
 	    # Check if branch exists before trying to rm it.
@@ -348,6 +358,7 @@ be pulled as $remote/pr/$number.
 EOF
 	    exit
 	fi
+	infer_remotes
 	infer_remote_type ${inferred_upstream}  # sets variable remote_type
 	for prnum in "$@"; do
 	    if [ "$remote_type" = "github" ] ; then
@@ -370,6 +381,7 @@ Fetch all PRs from a certain remote
 EOF
 	    exit
 	fi
+	infer_remotes
 	infer_remote_type ${inferred_upstream}
 	if [ "$remote_type" = "github" ] ; then
 	    git fetch ${inferred_upstream} "+refs/pull/*/head:refs/remotes/${inferred_upstream}/pr/*"
@@ -392,6 +404,7 @@ upstream.  It will delete anything matching '/pr/[0-9]+'
 EOF
 	    exit
 	fi
+	infer_remotes
 	git branch --remote -d $(git branch --remote ${inferred_upstream}/HEAD | grep -E "$inferred_upstream/pr/[0-9]\+$")
 	;;
 
@@ -405,6 +418,7 @@ It will delete anything matching '$upstream/pr/[0-9]+'
 EOF
 	    exit
 	fi
+	infer_remotes
 	git branch --remote --quiet -d $(git branch --remote --merged ${inferred_upstream}/HEAD | grep "$inferred_upstream/pr/[0-9]\+$")
 	;;
 
@@ -419,6 +433,7 @@ without PRs.
 EOF
 	    exit
 	fi
+	infer_remotes
 	brname=$(git symbolic-ref --short refs/remotes/origin/HEAD | cut -d/ -f2-)
 	if test -n \"$brname\" ; then
 	    git checkout $brname ;
@@ -433,6 +448,15 @@ EOF
 	;;
 
     info)
+	if test -n "$HELP" ; then
+	    cat <<EOF
+git pr inf
+
+Print out automatically inferred information about this repository.
+EOF
+	    exit
+	fi
+	infer_remotes
 	inferred_head="$(git symbolic-ref refs/remotes/${inferred_upstream}/HEAD --short)"
 	echo "Detected origin is ${inferred_origin}  (we push to here)"
 	echo "Detected upstream is ${inferred_upstream}  (we branch from here)"
@@ -449,6 +473,7 @@ Check the remote and set the remote default branch.
 EOF
 	    exit
 	fi
+	infer_remotes
 	git remote set-head ${inferred_upstream} --auto
 	;;
 


### PR DESCRIPTION
- Create a infer_remotes function which does the work that was
  previously done in the global namespace on every run.
- Run that function only when remotes need to be inferred (the
  commands that actually do something).
- Also add some missing help text.
- To review: This is somewhat straightforward, but also writing a raw
  shell script with no dependencies makes some hacks.  We could make
  sure the hacks aren't getting too much, but that is probably for a
  different time.

  - Ensure it is in all the places it needs to be
  - Ensure it's not missing anywhere
  - Realistically, we can just merge and fix it later