### PR TITLE
Add "open" command, rename `push -r` to `push -o`

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,31 +104,28 @@ Only a brief description is shown here.
   `fetch` before to make sure you are up to date.  With one argument,
   create a branch of this name, otherwise create a detached head.
 
-* `git pr push [-d] [-r]`: Push a PR.  With no arguments, send to inferred
+* `git pr push [-d] [-o] [[remote] branchname]`: Push a PR.  With no
+  arguments, send to inferred
   origin automatically with a name the same as the current branch.
   With one argument, send to a branch of that name.  With two
   arguments, the first is the remote name to use, and the second is
-  the branch name to push to.
+  the branch name to push to.  `-f` will force push.
 
-  Github: The `-r` option will create a pull
-  request at the same time (recursive invocation of `git pr gh`).  The
-  `-d` and `-n` options are passed to `git pr gh`.
+  Github: The `-o` option will create a pull
+  request at the same time.  `-n` will skip the "edit pull request
+  message" step and instead use the message from the (first) commit.
+  `-d` will open as a draft pull request.
 
   Gitlab: The `-r` option will create a merge request with git>=2.10
   and Gitlab>=11.10.  This is only opened on invocations that actually
   push something, since this uses [git push
   options](https://docs.gitlab.com/ce/user/project/push_options.html).
 
+* `git pr open`: Push and open a pull request.  This is completely
+  equivalent to `git pr push -o`, see above for documentation.
+
 * `git pr di`: Diff between current working dir and merge-base of
   inferred_upstream.
-
-* `git pr gh [-d]`: Create a Github pull request from the command line,
-  using the same type of logic as `git push` uses.  In general, it
-  does the right thing if you have just pushed a named branch.  If you
-  have pushed a detached head, you must give the branch name when
-  using this command.  (Gitlab pull requests are done within `git pr
-  push`).  `-d` creates a draft pull request.  `-n` doesn't prompt to
-  edit the PR  first (`hub pull-request --no-edit`).
 
 * `git pr rm $branch_name ...`: Remove named branches, both locally
   and on inferred_origin.

--- a/git-pr
+++ b/git-pr
@@ -41,7 +41,7 @@ print_help () {
 git-pr: git pull request helper.
 
 Subcommands:
-  Usual work:  branch, push, di, gh
+  Usual work:  branch, push, di, open
   Cleaning up:  merged, rm, prune
   Fetching PR branches:  fetch, fetchall, unfetchall
   Meta: info, set-head
@@ -121,9 +121,9 @@ EOF
     push)
 	if test -n "$HELP" ; then
 	    cat <<EOF
-git pr push [-d] [-f] [-r]
-git pr push [-d] [-f] [-r] BRNAME
-git pr push [-d] [-f] [-r] REMOTE BRNAME
+git pr push [-d] [-f] [-o]
+git pr push [-d] [-f] [-o] BRNAME
+git pr push [-d] [-f] [-o] REMOTE BRNAME
 
 Push a PR branch.
 
@@ -134,21 +134,22 @@ second is branch name.  If no arguments given, use the current branch
 name as the remote branch name (only works if you have a local
 branch).
 
-If "-f" is *first* argument, then force push.  If "-r" is after that,
-automatically make a PR (using "git pr gh"). "-d" and "-n" as in the "gh"
-subcommand (draft pull request, don't edit PR message).  The options have
-to be before the arguments.
+The options have to be before the arguments:
+-d   Open as a draft pull request (Github only)
+-f   Force push
+-n   Don't edit PR message before sending
+-o   Open a pull request, too (Gitlab/Github)
 EOF
 	    exit
 	fi
 	infer_remotes
 	# arg parsing
-	while getopts "dfnr" arg ; do
+	while getopts "dfnor" arg ; do
 	    case $arg in
 		d) PR_DRAFT="-d" ;;
 		f) FORCE="--force-with-lease" ;;
 		n) PR_NO_EDIT="-n" ;;
-		r) MAKE_PR=1 ;;
+		o|r) MAKE_PR=1 ;;
 	    esac
 	done
 	shift $((OPTIND-1))
@@ -187,6 +188,20 @@ EOF
 	if [ -n "$MAKE_PR" ] ; then
 	    echo "Can't make PR, can only make PRs for Gitlab/Github right now."
 	fi
+	;;
+
+    open)
+	if test -n "$HELP" ; then
+	    cat <<EOF
+git pr open [...]
+
+Push and open a pull request.  Opening is connected to pushing, so see
+"git pr push" for other options you can hive here.  This is a wrapper
+around "git pr push -o".
+
+EOF
+	fi
+	$0 push -o "$@"
 	;;
 
     di)


### PR DESCRIPTION
- open command: This is an alias for `git pr -o`, but provides a more
  logical entry point to recommend to people when they are starting.
  Open always pushes at the same time.
- This concept may still be developed, this is only the initial
  change.
- Remove documentation of the `gh` subcommand, it is almost never used
  directly.
- Part of #47.