### PR TITLE
Rename "di" command to "diff"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Features:
   on names `local`, `upstream`, `origin` (see below).
 * Anonymous PR branches (no local branch, only operating detached)
 * Fetch existing PR branches by number
-* Automatic diffs against upstream HEAD and PR branch: `git pr di`
+* Automatic diffs against upstream HEAD and PR branch: `git pr diff`
 * Delete local and remote branches at same time: `git pr rm`
 * Support for Gitlab and Github
 * Support for automatically making PRs/MRs (Github and gitlab>11.10).
@@ -119,7 +119,7 @@ Only a brief description is shown here.
   push something, since this uses [git push
   options](https://docs.gitlab.com/ce/user/project/push_options.html).
 
-* `git pr di`: Diff between current working dir and merge-base of
+* `git pr diff`: Diff between current working dir and merge-base of
   inferred_upstream.
 
 * `git pr gh [-d]`: Create a Github pull request from the command line,

--- a/git-pr
+++ b/git-pr
@@ -41,7 +41,7 @@ print_help () {
 git-pr: git pull request helper.
 
 Subcommands:
-  Usual work:  branch, push, di, gh
+  Usual work:  branch, push, diff, gh
   Cleaning up:  merged, rm, prune
   Fetching PR branches:  fetch, fetchall, unfetchall
   Meta: info, set-head
@@ -189,7 +189,7 @@ EOF
 	fi
 	;;
 
-    di)
+    diff|di)
 	if test -n "$HELP" ; then
 	    cat <<EOF
 git pr diff


### PR DESCRIPTION
- There was no reason for a short abbreviation here, so change the
  canonical name of the diff command to `diff`, from `di`
- Backwards compatibility remains but is not documented, there is
  little chance of problems later.